### PR TITLE
PR decidir metodo de pago

### DIFF
--- a/Decidir/AdminPlanesCuotas/Block/Adminhtml/Sales/Order/Invoice/Totals.php
+++ b/Decidir/AdminPlanesCuotas/Block/Adminhtml/Sales/Order/Invoice/Totals.php
@@ -56,7 +56,10 @@
         {
             $parent = $this->getParentBlock();
             $this->_order = $parent->getOrder();
-            $this->_source = $parent->getSource();
+	    if ($this->_order->getPayment()->getMethod() !== \Decidir\SpsDecidir\Model\Payment::CODE) {
+                return $this;
+            }
+	    $this->_source = $parent->getSource();
 
             $store = $this->getStore();
             $costo = 0;

--- a/Decidir/SpsDecidir/etc/frontend/di.xml
+++ b/Decidir/SpsDecidir/etc/frontend/di.xml
@@ -6,21 +6,11 @@
 */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-
-    <virtualType name="Decidir\SpsDecidir\Model\ConfigProvider" type="Magento\Payment\Model\CcGenericConfigProvider">
+    <type name="Magento\Payment\Model\CcGenericConfigProvider">
         <arguments>
             <argument name="methodCodes" xsi:type="array">
                 <item name="decidir_spsdecidir" xsi:type="const">Decidir\SpsDecidir\Model\Payment::CODE</item>
             </argument>
         </arguments>
-    </virtualType>
-
-    <type name="Magento\Checkout\Model\CompositeConfigProvider">
-        <arguments>
-            <argument name="configProviders" xsi:type="array">
-                <item name="decidir_spsdecidir_config_provider" xsi:type="object">Decidir\SpsDecidir\Model\ConfigProvider</item>
-            </argument>
-        </arguments>
     </type>
-
 </config>


### PR DESCRIPTION
se edita el di.xml en SpsDecidir para inyectar de la manera correcta el payment code en CcGenericConfigProvider y asi evitar doble llamado de este provider, el doble llamado puede generar doble datos en los demas modulos que inyectan sus payment codes, y esto puede generar duplicacion de datos por ejemplo en campos como los meses. la manera correcta de inyectar el codigo es apuntando directamente a la clase de Magento Payment co un Type y agregar el codigo dentro del array MethodCodes, no es necesario crear un Virtuyal Type.

agregar validacion en la clase Totals que se utiliza en los mail para verificar que el metodo de pago sea decidir, ya que si se tienen otros metodos de pago, se va a generar dentro del mail estos totales con valores de 0 incluso si el metodo de pago fue diferente al de decidir.